### PR TITLE
feat: specify the base container version v0.0.1 instead of latest

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,4 +1,4 @@
-ARG BASE_IMGAGE=ghcr.io/celestiaorg/explorer-base:latest
+ARG BASE_IMGAGE=ghcr.io/celestiaorg/explorer-base:v0.0.1
 FROM ${BASE_IMGAGE}
 
 # User data


### PR DESCRIPTION
## Overview

Tiny one, specify base docker version `v0.0.1` instead of `latest`.
